### PR TITLE
docs: fix direnv extension name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ export NODE_ENV="development"
     "vscode": {
       "extensions": [
         "jdinhlife.gruvbox",
-        "ms-vscode.vscode-direnv",
+        "mkhl.direnv",
         "ms-azuretools.vscode-docker"
       ]
     }


### PR DESCRIPTION
## Summary
- fix the direnv extension name in the sample devcontainer snippet in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687939b3df58832b84d504092ca7e682