### PR TITLE
Update dockerignore to include devcontainer Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@ Thumbs.db
 # Docker files (except the one we're building)
 Dockerfile*
 !Dockerfile
+!.devcontainer/Dockerfile
 .dockerignore
 
 # DevContainer files that shouldn't be in image


### PR DESCRIPTION
## Summary
- allow the devcontainer Dockerfile to be included in builds by updating `.dockerignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687939b39750832bb45b74dbbd26ce1e