### PR TITLE
Fix Docker build path in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     needs: lint
     steps:
       - name: Build Docker image
-        run: docker build -t dev-container:latest .
+        run: docker build -t dev-container:latest -f .devcontainer/Dockerfile .
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Summary
- fix Dockerfile path used in CI container-scan job

## Testing
- `bash install.sh`
- `.devcontainer/test-container.sh` *(fails: starship command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792e74f0c4832b937d3ea45fceb5d1